### PR TITLE
remove special animation case for collapsed view

### DIFF
--- a/library/src/main/java/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
+++ b/library/src/main/java/com/sothree/slidinguppanel/SlidingUpPanelLayout.java
@@ -416,12 +416,6 @@ public class SlidingUpPanelLayout extends ViewGroup {
         if (!mFirstLayout) {
             requestLayout();
         }
-
-        if (getPanelState() == PanelState.COLLAPSED) {
-            smoothToBottom();
-            invalidate();
-            return;
-        }
     }
 
     protected void smoothToBottom() {


### PR DESCRIPTION
The panel will always slide to a collapsed state when a new activity is launched, even though no drag events have occurred at that time. I think updating without an animation looks much more natural. If you don't plan on merging this I can maintain a fork, just let me know.